### PR TITLE
Add README summarizing blog content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# thefinalartefact.blog
+
+Hugo site for thefinalartefact.blog, built on PaperMod. The blog spans 2012-2026 with 26 posts focused on practical software, data, and tooling.
+
+## Content summary
+
+- Focus: R and Python workflows, data science/BI, and pragmatic engineering.
+- Tooling: Docker, Git, Neovim, Xcode, CLI utilities, code formatting, and automation.
+- Apps and infra: Shiny apps, Hive/Hadoop, deployment notes, and data pipelines.
+- Reviews and experiments: ML engineer review, ChatGPT drawing, and Codex-built tools.
+- Categories: BI, Data Science, dev, efficiency, example, fun, how-to, productivity, review, tools.
+
+## Post structure
+
+- Posts live in `content/post/YYYY-MM-DD-slug/` as page bundles.
+- Each post uses `index.md`, with assets stored alongside the post.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
 # thefinalartefact.blog
 
-Hugo site for thefinalartefact.blog, built on PaperMod. The blog spans 2012-2026 with 26 posts focused on practical software, data, and tooling.
-
-## Content summary
-
-- Focus: R and Python workflows, data science/BI, and pragmatic engineering.
-- Tooling: Docker, Git, Neovim, Xcode, CLI utilities, code formatting, and automation.
-- Apps and infra: Shiny apps, Hive/Hadoop, deployment notes, and data pipelines.
-- Reviews and experiments: ML engineer review, ChatGPT drawing, and Codex-built tools.
-- Categories: BI, Data Science, dev, efficiency, example, fun, how-to, productivity, review, tools.
-
-## Post structure
-
-- Posts live in `content/post/YYYY-MM-DD-slug/` as page bundles.
-- Each post uses `index.md`, with assets stored alongside the post.
+Hugo site for thefinalartefact.blog, built on PaperMod, with content focused on practical software, data, and tooling: R and Python workflows, data science/BI, Shiny apps, data pipelines, Docker and Git usage, editor and CLI setup, and occasional reviews or experiments.


### PR DESCRIPTION
## Summary
- add a README that summarizes the blog's topics, categories, and time span
- document the basic post bundle structure for context

## Testing
- markdownlint-cli2 (pre-commit)
- codespell (pre-commit)
- hugo-build (pre-commit)