### PR TITLE
Add control and agentic workflow article and PaperMod update

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,8 @@ markup:
     tabWidth: 4
 
 params:
+  author:
+    name: Konrad
   fuseOpts:
     isCaseSensitive: false
     shouldSort: true

--- a/content/post/2026-03-02-control-and-agentic-workflow/index.md
+++ b/content/post/2026-03-02-control-and-agentic-workflow/index.md
@@ -1,6 +1,6 @@
 ---
 title: Control and Agentic Workflow
-author: Konrad Zdeb
+author: Konrad
 date: "2026-03-02"
 slug: control-and-agentic-workflow
 categories:
@@ -13,24 +13,6 @@ tags:
 draft: true
 ---
 
-This is a draft stub for an article about balancing control with agentic workflows.
+In "The Slow Death of the Power User," Fireborn argues that big tech has steadily replaced user ownership and technical understanding with locked-down convenience, turning people into passive consumers of managed platforms. The article links smartphone ecosystems, algorithmic feeds, and surveillance-friendly defaults to a broader decline in technical literacy, not just for end users but for developers too, and warns that this weakens our ability to audit systems, migrate away from bad platforms, and hold vendors accountable. It closes with a call to rebuild practical autonomy through open protocols, self-hosting, and learning how our tools actually work. I was impressed by how clearly and forcefully the piece connects everyday convenience to long-term loss of control.
 
-## Background
-
-`TODO`: Describe what “agentic workflow” means in your context and why this topic matters now.
-
-## Problem
-
-`TODO`: Explain where fully manual workflows break down and where fully autonomous flows introduce risk.
-
-## Solution
-
-`TODO`: Present a practical model for keeping human control while benefiting from agentic execution.
-
-## Practical Workflow
-
-`TODO`: Add a step-by-step example (tools, guardrails, checkpoints, and escalation rules).
-
-## Summary
-
-`TODO`: Capture key tradeoffs and when to prefer more control vs. more autonomy.
+A further point is that locking development activity inside platform-governed ecosystems has eroded the older model of device ownership. In practice, a lot of commercial software work now resembles a lease arrangement between platform owner, device, and developer: if you want to build and monetise on iOS or Android, you are pushed into vendor-managed tooling, distribution, policy, and payment rails. Outside those pathways, commercialisation is close to impossible. We have not just outsourced distribution, but ceded a meaningful part of ownership itself.

--- a/content/post/2026-03-02-control-and-agentic-workflow/index.md
+++ b/content/post/2026-03-02-control-and-agentic-workflow/index.md
@@ -1,0 +1,36 @@
+---
+title: Control and Agentic Workflow
+author: Konrad Zdeb
+date: "2026-03-02"
+slug: control-and-agentic-workflow
+categories:
+  - productivity
+  - workflow
+tags:
+  - agentic
+  - control
+  - ai
+draft: true
+---
+
+This is a draft stub for an article about balancing control with agentic workflows.
+
+## Background
+
+`TODO`: Describe what “agentic workflow” means in your context and why this topic matters now.
+
+## Problem
+
+`TODO`: Explain where fully manual workflows break down and where fully autonomous flows introduce risk.
+
+## Solution
+
+`TODO`: Present a practical model for keeping human control while benefiting from agentic execution.
+
+## Practical Workflow
+
+`TODO`: Add a step-by-step example (tools, guardrails, checkpoints, and escalation rules).
+
+## Summary
+
+`TODO`: Capture key tradeoffs and when to prefer more control vs. more autonomy.

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ command = "hugo --gc --minify --baseURL=https://thefinalartefact.blog/"
 publish = "public"
 
 [build.environment]
-HUGO_VERSION = "0.148.1"
+HUGO_VERSION = "0.157.0"
 
 [context.production]
 command = "hugo --gc --minify --baseURL=https://thefinalartefact.blog/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@ HUGO_ENV = "production"
 
 # Make branch and preview builds use their own URL
 [context.branch-deploy]
-command = "hugo --gc --minify --baseURL=$DEPLOY_URL/"
+command = "hugo --gc --minify --buildDrafts --baseURL=$DEPLOY_URL/"
 
 [context.deploy-preview]
-command = "hugo --gc --minify --baseURL=$DEPLOY_PRIME_URL/"
+command = "hugo --gc --minify --buildDrafts --baseURL=$DEPLOY_PRIME_URL/"


### PR DESCRIPTION
## Summary
- add the control and agentic workflow article draft
- update the PaperMod submodule pointer to include upstream integration changes

## Notes
- This branch re-applies the article/theme commits so they are reviewed via PR instead of landing directly on master.