### PR TITLE
[codex] Update PaperMod submodule and pin Hugo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # thefinalartefact.xyz
 
 Hugo site for <https://www.thefinalartefact.xyz>, built on PaperMod, with content focused on practical software, data, and tooling: R and Python workflows, data science/BI, Shiny apps, data pipelines, Docker and Git usage, editor and CLI setup, and occasional reviews or experiments.
+
+## Local development
+
+Use the project-local Hugo binary so local validation matches Netlify:
+
+```sh
+npm install
+npm run server
+```
+
+Build locally with:
+
+```sh
+npm run build
+```
+
+The pinned Hugo version is `0.161.1`, matching `HUGO_VERSION` in `netlify.toml`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
+        "hugo-extended": "0.161.1",
         "stylelint": "^16.26.1",
         "stylelint-config-standard": "^36.0.1"
       }
@@ -179,6 +180,19 @@
         "url": "https://github.com/sponsors/JounQin"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@keyv/bigmap": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.0.tgz",
@@ -239,6 +253,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {
@@ -353,6 +377,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/color-convert": {
@@ -729,6 +763,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hugo-extended": {
+      "version": "0.161.1",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.161.1.tgz",
+      "integrity": "sha512-kFpyOR7Kn6GmzFDevruc5uvUDV5k1424iyYOoclFh5mcAJCJtMJ0ymLw+oul9vany6aYyN9vwRIkr1hSIluTlw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.17",
+        "tar": "^7.5.13"
+      },
+      "bin": {
+        "hugo": "dist/cli.mjs",
+        "hugo-extended": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -988,6 +1041,29 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -1506,6 +1582,23 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/tar": {
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1551,6 +1644,16 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,13 @@
 {
   "private": true,
+  "scripts": {
+    "hugo": "hugo",
+    "server": "hugo server -D",
+    "build": "hugo --gc --minify",
+    "build:production": "hugo --gc --minify --baseURL=https://www.thefinalartefact.xyz/"
+  },
   "devDependencies": {
+    "hugo-extended": "0.161.1",
     "stylelint": "^16.26.1",
     "stylelint-config-standard": "^36.0.1"
   }


### PR DESCRIPTION
## Summary

- Updates the `themes/PaperMod` submodule pointer to `187748e` after syncing with upstream PaperMod.
- Adds a project-local `hugo-extended@0.161.1` dev dependency and npm scripts for local build/server use.
- Documents the pinned local Hugo workflow in `README.md` so local checks match Netlify's `HUGO_VERSION`.

## Validation

- `npm run hugo -- version`
- `npm run build`
- `npm run build:production`
- `git diff --check`
- Side-by-side layout comparison with Hugo `0.161.1` across home, posts, taxonomy, tags, and search pages at desktop and mobile widths. Element boxes and scroll heights matched; remaining pixel diffs were confined to the theme-toggle icon.

## Notes

- The submodule commit was pushed to `konradzdeb/hugo-PaperMod` so the superproject pointer resolves on GitHub.
- `npm install` reported one moderate audit finding; this PR does not run `npm audit fix` or change unrelated dependencies.